### PR TITLE
Inject correct options object in SpnegoAuthenticator

### DIFF
--- a/src/RouteServiceAuth/SpnegoAuthenticator.cs
+++ b/src/RouteServiceAuth/SpnegoAuthenticator.cs
@@ -14,7 +14,7 @@ namespace RouteServiceAuth
     {
         private readonly KerberosAuthenticator _authenticator;
 
-        public SpnegoAuthenticator(IOptions<SpnegoAuthenticationOptions> options)
+        public SpnegoAuthenticator(IOptionsSnapshot<SpnegoAuthenticationOptions> options)
         {
             var spnegoAuthenticationOptions = options.Value;
             


### PR DESCRIPTION
The options object was injected directly but instead should be injected as an `IOptions<SpnegoAuthenticationOptions>` object.